### PR TITLE
BUG: Without login it navigate to home page instead of Error Page

### DIFF
--- a/src/components/Myself/Myself.jsx
+++ b/src/components/Myself/Myself.jsx
@@ -28,14 +28,16 @@ function Myself() {
     }
     if(isError){
         toast.error("Not login")
-        content = <ErrorPreview title={"Error"} message={"You are not Logined in, please login again"} />
+        navigate("/");
+        return;
     }
     if(data ){ 
         content = <ContentUser user={data} key={data._id} />
     }
     if(isErrorLog){
         toast.error("Error occurred !!!");
-        content = <ErrorPreview title={"Error"} message={error.message} />
+        navigate("/");
+        return;
     }
 
 


### PR DESCRIPTION
Fixes #4 When user try to access my-profile page without login so it fetch data from backend and in case of error it redirect to home page using navigate hook and simply return from that function.

**Testing:**

https://github.com/user-attachments/assets/100091a5-e804-4eac-b1da-6d2838a859b6




@manzil-infinity180  Please review my PR and merge accordingly:) 